### PR TITLE
Use env variables for mock data script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 # Supabase Configuration
 VITE_SUPABASE_URL=your-supabase-project-url
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+
+# Used by add-mockup-data.js
+SUPABASE_URL=your-supabase-project-url
+SUPABASE_ANON_KEY=your-supabase-anon-key

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ npm run dev
 Required environment variables:
 - `VITE_SUPABASE_URL`: Your Supabase project URL
 - `VITE_SUPABASE_ANON_KEY`: Your Supabase anonymous key
+- `SUPABASE_URL`: Used by `add-mockup-data.js` (usually same as `VITE_SUPABASE_URL`)
+- `SUPABASE_ANON_KEY`: Used by `add-mockup-data.js` (usually same as `VITE_SUPABASE_ANON_KEY`)
 
 These are configured in:
 - **Local development**: `.env.local` file

--- a/add-mockup-data.js
+++ b/add-mockup-data.js
@@ -1,8 +1,13 @@
 import { createClient } from '@supabase/supabase-js'
+import 'dotenv/config'
 
-// Supabase credentials
-const supabaseUrl = 'https://ipznnbmkdstkgdoivfyv.supabase.co'
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imlwem5uYm1rZHN0a2dkb2l2Znl2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTIyNzYyMTMsImV4cCI6MjA2Nzg1MjIxM30.I5PzmzsL3Li_Gq-Bww9KtQh4_KxQePmb6lxdj2L7TZI'
+// Supabase credentials from environment variables
+const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing Supabase environment variables')
+}
 
 const supabase = createClient(supabaseUrl, supabaseAnonKey)
 


### PR DESCRIPTION
## Summary
- load Supabase credentials in `add-mockup-data.js` from environment variables
- document new variables in README
- add variables to `.env.example`

## Testing
- `npm run lint` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68788d65c1a48324b48491c13fe0ed0b