### PR TITLE
Enable task navigation from sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { SparkApp } from "./components/SparkApp";
 import { onAuthStateChange } from "./lib/auth";
 import { testSupabaseConnection } from "./lib/supabase";
 import { SettingsProvider } from "./contexts/SettingsContext";
+import { TaskNavigationProvider } from "./hooks/useTaskNavigation";
 import type { User } from '@supabase/supabase-js';
 
 export default function App() {
@@ -41,6 +42,7 @@ export default function App() {
 
   return (
     <SettingsProvider>
+      <TaskNavigationProvider>
       <div className="min-h-screen flex flex-col" style={{ background: '#FAFAFA' }}>
         {user ? (
           <SparkApp />
@@ -62,6 +64,7 @@ export default function App() {
         )}
         <Toaster />
       </div>
+      </TaskNavigationProvider>
     </SettingsProvider>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { getTaskStats, subscribeToTasks, getTasks } from "../lib/queries/tasks";
 import { SignOutButton } from "../SignOutButton";
 import { Settings } from "./Settings";
 import { useSettings } from "../contexts/SettingsContext";
+import { useTaskNavigation } from "../hooks/useTaskNavigation";
 import type { Database } from "../lib/supabase";
 import ProgressCircle from "./ui/ProgressCircle";
 
@@ -140,6 +141,7 @@ export function Sidebar({
   const [projectCompletionStats, setProjectCompletionStats] = useState<Record<string, { completed: number; total: number }>>({});
   const [showSettings, setShowSettings] = useState(false);
   const { settings } = useSettings();
+  const { openTask } = useTaskNavigation();
 
   useEffect(() => {
     const fetchInitialData = async () => {
@@ -679,7 +681,11 @@ export function Sidebar({
                       {hasItems && settings.showProjectDropdowns && !isCollapsed && (
                         <div className="ml-5 border-l border-gray-200 pl-2 space-y-0">
                           {(projectTasks[project.id] || []).slice(0, 5).map((task) => (
-                            <div key={task.id} className="flex items-center gap-2 py-0.5 text-xs text-gray-600">
+                            <div
+                              key={task.id}
+                              className="flex items-center gap-2 py-0.5 text-xs text-gray-600 cursor-pointer"
+                              onClick={() => openTask(task.id)}
+                            >
                               <div className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${task.completed ? 'bg-green-500' : 'bg-gray-300'}`} />
                               <span className={`truncate leading-none ${task.completed ? 'line-through' : ''}`}>
                                 {task.title}
@@ -776,6 +782,7 @@ export function Sidebar({
                         key={task.id}
                         className="text-xs text-gray-600 py-0.5 px-2 hover:bg-gray-100 rounded cursor-pointer"
                         title={task.title}
+                        onClick={() => openTask(task.id)}
                       >
                         <div className="flex items-center gap-2">
                           <div className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${

--- a/src/components/SparkApp.tsx
+++ b/src/components/SparkApp.tsx
@@ -16,6 +16,7 @@ import { CalendarView } from "./CalendarView";
 import { TimeBlockingView } from "./TimeBlockingView";
 import { RecurringTaskForm } from "./RecurringTaskForm";
 import { TaskEditForm } from "./TaskEditForm"; // Import TaskEditForm
+import { useTaskNavigation } from "../hooks/useTaskNavigation";
 import { MockupDataButton } from "./MockupDataButton";
 import type { Database } from "../lib/supabase";
 import ProgressCircle from "./ui/ProgressCircle";
@@ -147,8 +148,7 @@ export function SparkApp() {
   const [showQuickEntry, setShowQuickEntry] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
   const [showRecurringForm, setShowRecurringForm] = useState(false);
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
-  const [showTaskEditForm, setShowTaskEditForm] = useState(false); // Corrected single declaration
+  const { selectedTaskId, openTask, closeTask } = useTaskNavigation();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [taskFilters, setTaskFilters] = useState<{
     priority?: "low" | "medium" | "high";
@@ -288,7 +288,7 @@ export function SparkApp() {
         setShowQuickEntry(false);
         setShowSearch(false);
         setShowRecurringForm(false);
-        setShowTaskEditForm(false); // Close TaskEditForm on escape
+        closeTask(); // Close TaskEditForm on escape
       }
     };
 
@@ -351,13 +351,11 @@ export function SparkApp() {
   };
 
   const handleOpenTaskEditForm = (taskId: string) => {
-    setSelectedTaskId(taskId);
-    setShowTaskEditForm(true);
+    openTask(taskId);
   };
 
   const handleCloseTaskEditForm = () => {
-    setSelectedTaskId(null);
-    setShowTaskEditForm(false);
+    closeTask();
   };
 
   return (
@@ -699,7 +697,7 @@ export function SparkApp() {
         />
       )}
 
-      {showTaskEditForm && selectedTaskId && (
+      {selectedTaskId && (
         <TaskEditForm
           task={tasks.find(t => t.id === selectedTaskId)}
           onClose={handleCloseTaskEditForm}

--- a/src/hooks/useTaskNavigation.ts
+++ b/src/hooks/useTaskNavigation.ts
@@ -1,0 +1,30 @@
+import { createContext, useContext, useState } from 'react';
+
+interface TaskNavigationContext {
+  selectedTaskId: string | null;
+  openTask: (id: string) => void;
+  closeTask: () => void;
+}
+
+const TaskNavigationContext = createContext<TaskNavigationContext | undefined>(undefined);
+
+export function TaskNavigationProvider({ children }: { children: React.ReactNode }) {
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+
+  const openTask = (id: string) => setSelectedTaskId(id);
+  const closeTask = () => setSelectedTaskId(null);
+
+  return (
+    <TaskNavigationContext.Provider value={{ selectedTaskId, openTask, closeTask }}>
+      {children}
+    </TaskNavigationContext.Provider>
+  );
+}
+
+export function useTaskNavigation() {
+  const context = useContext(TaskNavigationContext);
+  if (!context) {
+    throw new Error('useTaskNavigation must be used within a TaskNavigationProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add `useTaskNavigation` hook to manage currently opened task
- wrap app with `TaskNavigationProvider`
- use the hook in `SparkApp` and open tasks via context
- add click handlers in `Sidebar` to open tasks

## Testing
- `npm run lint` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878988486488324be4dd4bc3418d6e6