### PR TITLE
Implement task store and integrate across components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { SparkApp } from "./components/SparkApp";
 import { onAuthStateChange } from "./lib/auth";
 import { testSupabaseConnection } from "./lib/supabase";
 import { SettingsProvider } from "./contexts/SettingsContext";
+import { TaskStoreProvider } from "./stores/useTaskStore";
 import type { User } from '@supabase/supabase-js';
 
 export default function App() {
@@ -41,10 +42,11 @@ export default function App() {
 
   return (
     <SettingsProvider>
-      <div className="min-h-screen flex flex-col" style={{ background: '#FAFAFA' }}>
-        {user ? (
-          <SparkApp />
-        ) : (
+      <TaskStoreProvider>
+        <div className="min-h-screen flex flex-col" style={{ background: '#FAFAFA' }}>
+          {user ? (
+            <SparkApp />
+          ) : (
           <div className="flex-1 flex items-center justify-center p-8">
             <div className="w-full max-w-md mx-auto">
               <div className="bg-white rounded-2xl shadow-2xl border border-gray-100 p-8">
@@ -59,9 +61,10 @@ export default function App() {
               </div>
             </div>
           </div>
-        )}
-        <Toaster />
-      </div>
+          )}
+          <Toaster />
+        </div>
+      </TaskStoreProvider>
     </SettingsProvider>
   );
 }

--- a/src/components/QuickEntry.tsx
+++ b/src/components/QuickEntry.tsx
@@ -1,21 +1,23 @@
 import { useState, useEffect, useRef } from "react";
 import { createTask } from "../lib/queries/tasks";
 
+import { useTaskStore } from "../stores/useTaskStore";
+
 interface QuickEntryProps {
   isVisible: boolean;
   onClose: () => void;
   projectId?: string | null;
   areaId?: string | null;
-  onTaskCreated?: () => void;
 }
 
-export function QuickEntry({ isVisible, onClose, projectId, areaId, onTaskCreated }: QuickEntryProps) {
+export function QuickEntry({ isVisible, onClose, projectId, areaId }: QuickEntryProps) {
   const [title, setTitle] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [currentDate, setCurrentDate] = useState(new Date());
   const [searchQuery, setSearchQuery] = useState("");
   const modalRef = useRef<HTMLDivElement>(null);
+  const { refresh } = useTaskStore();
 
   const generateCalendarDays = () => {
     const currentMonth = currentDate.getMonth();
@@ -123,11 +125,7 @@ export function QuickEntry({ isVisible, onClose, projectId, areaId, onTaskCreate
       });
       console.log('✅ Task created successfully');
       
-      // Manually refresh task cache immediately
-      if (onTaskCreated) {
-        console.log('🔄 Triggering cache refresh...');
-        onTaskCreated();
-      }
+      await refresh();
       
       setTitle("");
       setDueDate("");

--- a/src/components/RecurringTaskForm.tsx
+++ b/src/components/RecurringTaskForm.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { createRecurringTask, updateRecurringTask, updateTask } from "../lib/queries/tasks";
+import { useTaskStore } from "../stores/useTaskStore";
 import { supabase } from "../lib/supabase";
 import type { Database } from "../lib/supabase";
 
@@ -18,6 +19,7 @@ export function RecurringTaskForm({ isVisible, onClose, taskId }: RecurringTaskF
   const [endDate, setEndDate] = useState("");
   const [occurrences, setOccurrences] = useState<number | null>(null);
   const [recurringTask, setRecurringTask] = useState<RecurringTask | null>(null);
+  const { refresh } = useTaskStore();
 
   useEffect(() => {
     const fetchRecurringTask = async () => {
@@ -71,7 +73,7 @@ export function RecurringTaskForm({ isVisible, onClose, taskId }: RecurringTaskF
         await updateTask(taskId, { recurring_rule_id: newRecurringTask.id, is_recurring: true });
       }
     }
-
+    await refresh();
     onClose();
   };
 

--- a/src/components/SparkApp.tsx
+++ b/src/components/SparkApp.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
 import { getCurrentUser, signOut } from "../lib/auth";
-import { getTaskStats, getTasks, subscribeToTasks } from "../lib/queries/tasks";
+import { getTaskStats } from "../lib/queries/tasks";
 import { getProjects } from "../lib/queries/projects";
 import { getAreas } from "../lib/queries/areas";
+import { useTaskStore } from "../stores/useTaskStore";
 import { SignOutButton } from "../SignOutButton";
 import { Sidebar } from "./Sidebar";
 import { TaskList } from "./TaskList";
@@ -160,105 +161,16 @@ export function SparkApp() {
   const [taskStats, setTaskStats] = useState(null);
   const [projects, setProjects] = useState<Project[]>([]);
   const [areas, setAreas] = useState<Area[]>([]);
-  const [tasks, setTasks] = useState<Task[]>([]); // Add tasks state to SparkApp
-  const [allTasks, setAllTasks] = useState<Task[]>([]); // Cache all tasks for instant filtering
+  const { tasks: allTasks, refresh: refreshTaskCache } = useTaskStore();
 
-  // Function to manually refresh the task cache
-  const refreshTaskCache = async () => {
-    try {
-      console.log('📝 Manually refreshing task cache...');
-      const updatedTasks = await getTasks({ view: 'all' });
-      console.log('📝 Manual cache refresh:', updatedTasks.length, 'tasks');
-      setAllTasks(updatedTasks);
-    } catch (error) {
-      console.error('Error manually refreshing task cache:', error);
-    }
-  };
 
   useEffect(() => {
     getCurrentUser().then(setUser);
     getTaskStats().then(setTaskStats).catch(() => setTaskStats(null));
     getProjects().then(setProjects).catch(() => setProjects([]));
     getAreas().then(setAreas).catch(() => setAreas([]));
-    
-    // Fetch ALL tasks once and cache them
-    getTasks({ view: 'all' })
-      .then((fetchedTasks) => {
-        console.log('All tasks cached on startup:', fetchedTasks.length, 'tasks');
-        setAllTasks(fetchedTasks);
-      })
-      .catch((error) => {
-        console.error('Error fetching all tasks:', error);
-        setAllTasks([]);
-      });
+  }, []);
 
-    // Subscribe to task changes to keep cache updated
-    console.log('Setting up task subscription...');
-    const taskSubscription = subscribeToTasks(async () => {
-      try {
-        console.log('🔥 Task change detected, updating cache...');
-        const updatedTasks = await getTasks({ view: 'all' });
-        console.log('🔥 Cache updated with:', updatedTasks.length, 'tasks');
-        setAllTasks(updatedTasks);
-      } catch (error) {
-        console.error('Error updating task cache:', error);
-      }
-    });
-
-    return () => {
-      taskSubscription.unsubscribe();
-    };
-  }, []); // Only run once on component mount
-
-  // Filter cached tasks instantly when view/project changes
-  useEffect(() => {
-    const filterTasks = () => {
-      console.log('Filtering tasks instantly for:', { currentView, selectedProjectId, selectedAreaId });
-      
-      let filteredTasks = allTasks;
-      
-      // Filter by project/area first
-      if (selectedProjectId) {
-        filteredTasks = allTasks.filter(task => task.project_id === selectedProjectId);
-      } else if (selectedAreaId) {
-        // Show tasks that belong to projects within this area OR tasks directly assigned to this area
-        const areaProjectIds = projects.filter(p => p.area_id === selectedAreaId).map(p => p.id);
-        filteredTasks = allTasks.filter(task => 
-          task.area_id === selectedAreaId || 
-          (task.project_id && areaProjectIds.includes(task.project_id))
-        );
-      }
-      
-      // Then apply view filters
-      if (currentView === 'inbox' && !selectedProjectId && !selectedAreaId) {
-        // For inbox view without specific project, show all tasks for grouping
-        filteredTasks = allTasks;
-      } else if (currentView === 'today') {
-        const today = new Date();
-        today.setHours(23, 59, 59, 999);
-        const todayEnd = today.getTime();
-        filteredTasks = filteredTasks.filter(task => 
-          !task.completed && (
-            (task.scheduled_date && new Date(task.scheduled_date).getTime() <= todayEnd) ||
-            (task.due_date && new Date(task.due_date).getTime() <= todayEnd)
-          )
-        );
-      } else if (currentView === 'completed') {
-        filteredTasks = filteredTasks.filter(task => task.completed);
-      } else {
-        // For other views or project-specific views, show non-completed tasks
-        filteredTasks = filteredTasks.filter(task => !task.completed);
-      }
-      
-      console.log('Filtered tasks result:', filteredTasks);
-      console.log('Setting tasks to:', filteredTasks.length, 'tasks');
-      setTasks(filteredTasks);
-    };
-    
-    if (allTasks.length > 0) {
-      filterTasks();
-    }
-  }, [currentView, selectedProjectId, selectedAreaId, allTasks]);
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -583,7 +495,6 @@ export function SparkApp() {
                   areaId={selectedAreaId}
                   filters={taskFilters}
                   onEditTask={handleOpenTaskEditForm}
-                  tasks={tasks}
                 />
               </>
             )}
@@ -666,7 +577,6 @@ export function SparkApp() {
           onClose={() => setShowTaskForm(false)}
           projectId={selectedProjectId}
           areaId={selectedAreaId}
-          onTaskCreated={refreshTaskCache}
         />
       )}
 
@@ -701,9 +611,8 @@ export function SparkApp() {
 
       {showTaskEditForm && selectedTaskId && (
         <TaskEditForm
-          task={tasks.find(t => t.id === selectedTaskId)}
+          task={allTasks.find(t => t.id === selectedTaskId)!}
           onClose={handleCloseTaskEditForm}
-          onTaskUpdated={refreshTaskCache}
         />
       )}
 
@@ -719,7 +628,6 @@ export function SparkApp() {
         onClose={() => setShowQuickEntry(false)}
         projectId={null}
         areaId={null}
-        onTaskCreated={refreshTaskCache}
       />
 
     </div>

--- a/src/components/TaskEditForm.tsx
+++ b/src/components/TaskEditForm.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { updateTask } from "../lib/queries/tasks";
 import { getProjects } from "../lib/queries/projects";
 import { getAreas } from "../lib/queries/areas";
+import { useTaskStore } from "../stores/useTaskStore";
 import type { Database } from "../lib/supabase";
 
 type Task = Database['public']['Tables']['tasks']['Row'];
@@ -11,10 +12,9 @@ type Area = Database['public']['Tables']['areas']['Row'];
 interface TaskEditFormProps {
   task: Task;
   onClose: () => void;
-  onTaskUpdated?: () => void;
 }
 
-export function TaskEditForm({ task, onClose, onTaskUpdated }: TaskEditFormProps) {
+export function TaskEditForm({ task, onClose }: TaskEditFormProps) {
   const [title, setTitle] = useState(task.title);
   const [notes, setNotes] = useState(task.notes || "");
   const [dueDate, setDueDate] = useState(
@@ -39,6 +39,7 @@ export function TaskEditForm({ task, onClose, onTaskUpdated }: TaskEditFormProps
   const [currentScheduledDate, setCurrentScheduledDate] = useState(new Date());
   const [currentDueDate, setCurrentDueDate] = useState(new Date());
   const modalRef = useRef<HTMLDivElement>(null);
+  const { refresh } = useTaskStore();
 
   useEffect(() => {
     const fetchDropdownData = async () => {
@@ -172,11 +173,7 @@ export function TaskEditForm({ task, onClose, onTaskUpdated }: TaskEditFormProps
       });
       console.log('✅ Task updated successfully');
       
-      // Manually refresh task cache immediately
-      if (onTaskUpdated) {
-        console.log('🔄 Triggering cache refresh...');
-        onTaskUpdated();
-      }
+      await refresh();
       
       onClose();
     } catch (error) {

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { createTask, updateTask } from "../lib/queries/tasks";
 import { getProjects } from "../lib/queries/projects";
 import { getAreas } from "../lib/queries/areas";
+import { useTaskStore } from "../stores/useTaskStore";
 import type { Database } from "../lib/supabase";
 
 type Task = Database['public']['Tables']['tasks']['Row'];
@@ -13,7 +14,6 @@ interface TaskFormProps {
   projectId?: string | null;
   areaId?: string | null;
   task?: Task;
-  onTaskCreated?: () => void;
 }
 
 // Locally-scoped styles for the test
@@ -31,7 +31,7 @@ const styles = `
   }
 `;
 
-export function TaskForm({ onClose, projectId, areaId, task, onTaskCreated }: TaskFormProps) {
+export function TaskForm({ onClose, projectId, areaId, task }: TaskFormProps) {
   const [title, setTitle] = useState(task?.title || "");
   const [notes, setNotes] = useState(task?.notes || "");
   const [dueDate, setDueDate] = useState(
@@ -49,6 +49,7 @@ export function TaskForm({ onClose, projectId, areaId, task, onTaskCreated }: Ta
   const [projects, setProjects] = useState<Project[]>([]);
   const [areas, setAreas] = useState<Area[]>([]);
   const modalRef = useRef<HTMLDivElement>(null);
+  const { refresh } = useTaskStore();
   
   // Calendar popup states
   const [showScheduledDatePicker, setShowScheduledDatePicker] = useState(false);
@@ -197,11 +198,7 @@ export function TaskForm({ onClose, projectId, areaId, task, onTaskCreated }: Ta
         console.log('✅ Task created successfully');
       }
       
-      // Manually refresh task cache immediately
-      if (onTaskCreated) {
-        console.log('🔄 Triggering cache refresh...');
-        onTaskCreated();
-      }
+      await refresh();
       
       onClose();
     } catch (error) {

--- a/src/stores/useTaskStore.ts
+++ b/src/stores/useTaskStore.ts
@@ -1,0 +1,46 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import { getTasks, subscribeToTasks } from '../lib/queries/tasks'
+import type { Database } from '../lib/supabase'
+
+type Task = Database['public']['Tables']['tasks']['Row']
+
+interface TaskStore {
+  tasks: Task[]
+  refresh: () => Promise<void>
+}
+
+const TaskStoreContext = createContext<TaskStore | undefined>(undefined)
+
+export function TaskStoreProvider({ children }: { children: React.ReactNode }) {
+  const [tasks, setTasks] = useState<Task[]>([])
+
+  const refresh = async () => {
+    try {
+      const fetched = await getTasks({ view: 'all' })
+      setTasks(fetched)
+    } catch (err) {
+      console.error('Failed to refresh tasks:', err)
+      setTasks([])
+    }
+  }
+
+  useEffect(() => {
+    refresh()
+    const channel = subscribeToTasks(refresh)
+    return () => {
+      channel.unsubscribe()
+    }
+  }, [])
+
+  return (
+    <TaskStoreContext.Provider value={{ tasks, refresh }}>
+      {children}
+    </TaskStoreContext.Provider>
+  )
+}
+
+export function useTaskStore() {
+  const ctx = useContext(TaskStoreContext)
+  if (!ctx) throw new Error('useTaskStore must be used within TaskStoreProvider')
+  return ctx
+}


### PR DESCRIPTION
## Summary
- add `useTaskStore` with cache and realtime updates
- wrap app with `TaskStoreProvider`
- update components to use the task store instead of passing tasks
- simplify task refresh handling

## Testing
- `npm run lint` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878988b2b0883249713ba199e32ee80