### PR TITLE
refactor Sidebar user prop

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import type { User } from "@supabase/supabase-js";
 import { getProjects, subscribeToProjects } from "../lib/queries/projects";
 import { getAreas, subscribeToAreas } from "../lib/queries/areas";
 import { getTaskStats, subscribeToTasks, getTasks } from "../lib/queries/tasks";
@@ -107,7 +108,7 @@ interface SidebarProps {
   onEditArea: (area: Area) => void;
   onNewTask: () => void;
   onQuickEntry: () => void;
-  user: any;
+  user: User | null;
   collapsed: boolean;
   onToggleCollapse: () => void;
 }

--- a/src/components/SparkApp.tsx
+++ b/src/components/SparkApp.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import type { User } from "@supabase/supabase-js";
 import { getCurrentUser, signOut } from "../lib/auth";
 import { getTaskStats, getTasks, subscribeToTasks } from "../lib/queries/tasks";
 import { getProjects } from "../lib/queries/projects";
@@ -156,7 +157,7 @@ export function SparkApp() {
     dateRange?: "today" | "week" | "month";
   }>({});
 
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState<User | null>(null);
   const [taskStats, setTaskStats] = useState(null);
   const [projects, setProjects] = useState<Project[]>([]);
   const [areas, setAreas] = useState<Area[]>([]);


### PR DESCRIPTION
## Summary
- enforce Supabase `User` type in Sidebar
- update SparkApp to pass `User | null`

## Testing
- `npx tsc -p . --noEmit`
- `npm run lint` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878989329588324a80edf333a465f4f